### PR TITLE
Allow to await the unlockWithLicense method

### DIFF
--- a/ios/Classes/FlutterVESDK.swift
+++ b/ios/Classes/FlutterVESDK.swift
@@ -95,6 +95,9 @@ public class FlutterVESDK: FlutterIMGLY, FlutterPlugin, VideoEditViewControllerD
             guard let license = arguments["license"] as? String else { return }
             self.result = result
             self.unlockWithLicense(with: license)
+            
+            result(nil)
+            return
         }
     }
 

--- a/lib/video_editor_sdk.dart
+++ b/lib/video_editor_sdk.dart
@@ -18,7 +18,7 @@ class VESDK {
   /// to include one license for each platform with the same name, but where
   /// the iOS license has `.ios` as its file extension and the
   /// Android license has `.android` as its file extension.
-  static void unlockWithLicense(String path) async {
+  static Future<void> unlockWithLicense(String path) async {
     await _channel.invokeMethod('unlock', <String, dynamic>{'license': path});
   }
 


### PR DESCRIPTION
The method `unlockWithLicense()` cannot be awaited.
Without the ability to await this method, if the method is called just before `openEditor()`, it can randomly cause the error "FlutterError(code: "Multiple requests.", message: "Cancelled due to multiple requests.", details: nil)".

Also is a good practice that an async function always returns a Future.